### PR TITLE
The quality of the images has been increased

### DIFF
--- a/src/core/styles.ts
+++ b/src/core/styles.ts
@@ -1,20 +1,20 @@
 export const previewStyles = `
     :root { --main-bg-color: #1e1e1e; --dark-theme-bg-color: #1e1e1e; --dark-theme-font-color: #fafafa; --light-theme-bg-color: #f3f3f3; --light-theme-font-color: #424242; }
-    body { margin: 0; padding: 0; font-family: arial, sans-serif; border-collapse: collapse; width: 100%; background: var(--main-bg-color); font-size: 1rem; }
-    .theme-review { display: grid; grid-template-columns: 1fr 1fr; grid-template-rows: 1fr; width: 600px; }
+    body { margin: 0; padding: 0; font-family: arial, sans-serif; border-collapse: collapse; width: 100%; background: var(--main-bg-color); font-size: 2rem; }
+    .theme-review { display: grid; grid-template-columns: 2fr 2fr; grid-template-rows: 2fr; width: 3200px; }
     .theme-review ul { list-style: none; padding: 0; margin: 0; }
     .theme-review ul > li { line-height: 1.5;}
     .theme-review ul > li.with-big-icon { line-height: 3;}
-    .theme-container { padding: 1rem; }
-    .theme-container > h2 { font-size: 1rem; margin-top: 0; }
+    .theme-container { padding: 4rem; }
+    .theme-container > h2 { font-size: 4rem; margin-top: 0; }
     .theme-container.dark { color: var(--dark-theme-font-color); background: var(--dark-theme-bg-color); }
     .theme-container.dark .divider { background: var(--dark-theme-font-color); }
     .theme-container.light { color: var(--light-theme-font-color); background: var(--light-theme-bg-color); }
     .theme-container.light .divider { background: var(--light-theme-font-color); }
-    .icon { display: grid; align-items: center; white-space: nowrap; grid-template-columns: 16px auto; gap: 5px; }
-    .icon.with-big-icon { grid-template-columns: 32px 16px 16px auto; }
-    .icon-preview { content: " "; background-size: 32px; background-position: 0; background-repeat: no-repeat; width: 32px; height: 32px; }
-    .divider { height: 75%; width: 1px; justify-self: center; border-radius: 16px; }
-    .icon-preview-small { content: ' '; background-size: 16px; background-position: 0; background-repeat: no-repeat; width: 16px; height: 16px; }
-    .icon > span { font-size: 13px; text-overflow: ellipsis; overflow: hidden; }
+    .icon { display: grid; align-items: center; white-space: nowrap; grid-template-columns: 64px auto; gap: 20px; }
+    .icon.with-big-icon { grid-template-columns: 128px 64px 64px auto; }
+    .icon-preview { content: ' '; background-size: 128px; background-position: 0; background-repeat: no-repeat; width: 128px; height: 128px; }
+    .divider { height: 75%; width: 4px; justify-self: center; border-radius: 16px; }
+    .icon-preview-small { content: ' '; background-size: 64px; background-position: 0; background-repeat: no-repeat; width: 64px; height: 64px; filter: blur(1px); }
+    .icon > span { font-size: 52px; text-overflow: ellipsis; overflow: hidden; }
 `;

--- a/src/core/utils/screenshot.ts
+++ b/src/core/utils/screenshot.ts
@@ -13,7 +13,7 @@ export const createScreenshot = async (filePath: string, fileName: string) => {
       headless: true,
     });
     const page = await browser.newPage();
-    await page.setViewport({ width: 800, height: 800, deviceScaleFactor: 1 });
+    await page.setViewport({ width: 3200, height: 3200, deviceScaleFactor: 0 });
 
     await page.goto(htmlFilePath);
 


### PR DESCRIPTION
I increased the quality of the preview icon and also added blur for the small icon as I said in https://github.com/PKief/svg-icon-review/issues/1#issuecomment-2230176028

Here is an example of the image it now displays:

![image](https://github.com/user-attachments/assets/a4aa3f09-ffb4-4de3-b084-c3c1df4dfe46)

---

I'll check later if the server actually returns the lower resolution image as stated in https://github.com/PKief/svg-icon-review/issues/1#issuecomment-2230187506 which is very strange because on the main the service page says that the [maximum file size is **128 MB**](https://freeimage.host/en#:~:text=your%20images%20now.-,128%20MB%20limit,-.%20Direct%20image%20links)